### PR TITLE
Change Cirq dependency to `cirq-core` and support Python 3.13.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ The **Unitary Compiler Collection (UCC)** is a Python library for frontend-agnos
 
 ### Installation
 
-You will require **Python 3.12**. **Note:** the
-newest Python version 3.13 is not yet supported due to several dependencies not yet
-supporting it.
 
 ```bash
 git clone https://github.com/unitaryfund/ucc.git

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,10 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],
-    python_requires="==3.12",  # Python version required
+    python_requires=">=3.12",  # Python version required
     install_requires=[
         "qiskit>=0.41.0",
-        "cirq>=0.13.0",
+        "cirq-core>=1.4.0",
         "pytket>=1.3.0",
         "qbraid>=0.7.3",
         "ply",


### PR DESCRIPTION
Allow support for Python 3.13 by specifying [`cirq-core`](https://github.com/quantumlib/Cirq/tree/main/cirq-core) as dependency instead of `cirq`