### PR TITLE
Test that gateset is preserved

### DIFF
--- a/ucc/tests/test_compile.py
+++ b/ucc/tests/test_compile.py
@@ -37,7 +37,7 @@ def test_tket_compile():
 @pytest.mark.parametrize("circuit_function", [qcnn_circuit, random_clifford_circuit])
 @pytest.mark.parametrize("num_qubits", [4, 5, 6, 7, 8, 9, 10])
 @pytest.mark.parametrize("seed", [1, 326, 5678, 12345])
-def test_gateset_of_out_circuit(circuit_function, num_qubits, seed):
+def test_compilation_retains_gateset(circuit_function, num_qubits, seed):
     circuit = circuit_function(num_qubits, seed)
     transpiler = UCCDefault1()
     target_basis = transpiler.target_basis


### PR DESCRIPTION
Fixes #82 .

Adds a test to check if output circuits have gates outside of the gateset specified by the UCC `BasisTranslator`.

As expected, the test added here passes when `CollectCliffords` is commented out but otherwise fails on the `random_clifford` cases.