### PR TITLE
Pin to Qiskit 1.2 temporarily

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=0.41.0
+qiskit==1.2.0
 cirq-core>=1.4.0
 pytket>=1.3.0
 qbraid>=0.7.3


### PR DESCRIPTION
Qiskti 1.3.0 has broken the build (#111), pinning this as a temporary workaround