### PR TITLE
fix small_test.sh CLI command to deal with spaces in paths

### DIFF
--- a/benchmarks/scripts/small_test.sh
+++ b/benchmarks/scripts/small_test.sh
@@ -7,6 +7,6 @@ mkdir -p "$RESULTS_FOLDER"
 QASM_FOLDER="$SCRIPT_DIR/../qasm_circuits/"
 full_qasm_file="$QASM_FOLDER/$QASM_FILE"
 
-command="python3.12 \"$SCRIPT_DIR/benchmark_script.py\" \"$full_qasm_file\" \"$COMPILER\" \"$RESULTS_FOLDER\""
+command="python3 \"$SCRIPT_DIR/benchmark_script.py\" \"$full_qasm_file\" \"$COMPILER\" \"$RESULTS_FOLDER\""
 
 eval $command


### PR DESCRIPTION
This is a small fix for a bug that came up when I had a space in my general path.