### PR TITLE
Use idiomatic circuit.num_nonlocal_gates for qiskit circuits

### DIFF
--- a/benchmarks/scripts/common.py
+++ b/benchmarks/scripts/common.py
@@ -262,11 +262,7 @@ def count_multi_qubit_gates_pytket(pytket_circuit):
 
 # Multi-qubit gate count for Qiskit
 def count_multi_qubit_gates_qiskit(qiskit_circuit):
-    return sum(
-        1
-        for instruction, _, _ in qiskit_circuit.data
-        if instruction.num_qubits > 1
-    )
+    return qiskit_circuit.num_nonlocal_gates()
 
 
 # Multi-qubit gate count for Cirq

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -34,7 +34,6 @@ For example, we can define a random circuit in Qiskit and optimize it using the 
 
    from qiskit.circuit.random import random_clifford_circuit
    import ucc
-   from benchmarks.scripts.common import count_multi_qubit_gates_qiskit
 
 
    gates = ["cx", "cz", "cy", "swap", "x", "y", "z", "s", "sdg", "h"]
@@ -43,13 +42,8 @@ For example, we can define a random circuit in Qiskit and optimize it using the 
       num_qubits, gates=gates, num_gates=10 * num_qubits * num_qubits
    )
    compiled_circuit = ucc.compile(raw_circuit)
-   print(
-      f"Number of multi-qubit gates in original circuit: {count_multi_qubit_gates_qiskit(raw_circuit)}"
-   )
-   print(
-      f"Number of multi-qubit gates in compiled circuit: {count_multi_qubit_gates_qiskit(compiled_circuit)}"
-   )
-
+   print(f"Number of multi-qubit gates in original circuit: {raw_circuit.num_nonlocal_gates()}")
+   print(f"Number of multi-qubit gates in compiled circuit: {compiled_circuit.num_nonlocal_gates()}")
 
 .. testoutput::
    :hide:


### PR DESCRIPTION
While working on a demo notebook, I came across the qiskit provided `num_nonlocal_gates()` as a preferred way to count the multi-qubit gates in a qiskit circuit. Quick update to use that internally.

[qiskit docs](https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.QuantumCircuit#num_nonlocal_gates) for this function