### PR TITLE
Add workflow to trigger ucc-bench run

### DIFF
--- a/.github/workflows/trigger-ucc-bench.yml
+++ b/.github/workflows/trigger-ucc-bench.yml
@@ -1,0 +1,36 @@
+# Trigger an upgrade of ucc version  in ucc-bench repo in response to push to main
+# To trigger an event in the other repo, we had to install a GitHub app in the
+# ucc-bench repo, and then add the app ID/private key as secrets to this repo
+# so it could trigger the workflow. See
+# https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions
+# for details.
+
+name: Trigger ucc upgrade in ucc-bench
+on:
+  push:
+    branches:
+      - main
+jobs:
+  trigger-benchmarks:
+    runs-on: ubuntu-latest
+    # Don't run on forks or original benchmark commits
+    if: ${{ github.repository == 'unitaryfoundation/ucc' && !contains(github.event.head_commit.message, '[benchmark chore]') }}
+
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.UCC_BENCH_APP_ID }}
+          private-key: ${{ secrets.UCC_BENCH_APP_PRIVATE_KEY }}
+
+      - name: Trigger ucc-main-push event in ucc-bench
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/unitaryfoundation/ucc-bench/dispatches \
+            -f "event_type=ucc-main-push" -F "client_payload[commit_hash]=${{ github.sha }}"


### PR DESCRIPTION
This workflow will trigger a benchmark run in the new `ucc-bench` repo on a merge to main in `ucc`. 

This leverage [`repository_dispatch`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#repository_dispatch), where the action in the `ucc` repo calls a rest API to trigger an action in `ucc-bench`. The permissions were managed by creating a GitHub APP, installing that app into the `ucc-bench` repo with proper permissions, and then adding the app's key as secrets to the `ucc` repo.

We can run the existing benchmarking code within `ucc` and the new code in `ucc-bench` in parallel and then chose to cut-over when ready. The `ucc-bench` code is still finalizing, but I would like to enable this trigger sooner to test it, but then also start capturing the benchmark results as `ucc` development continues.

Resolve #326 
