### PR TITLE
342 target gateset

### DIFF
--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -28,7 +28,7 @@ supported_circuit_formats = ConversionGraph().nodes()
 def compile(
     circuit,
     return_format="original",
-    return_gateset=None,
+    target_gateset=None,
     target_device=None,
     custom_passes=None,
 ):
@@ -41,7 +41,7 @@ def compile(
         return_format (str): The format in which your circuit will be returned.
             e.g., "TKET", "OpenQASM2". Check ``ucc.supported_circuit_formats()``.
             Defaults to the format of the input circuit.
-        return_gateset (set[str]): (optional) The gateset to compile the circuit to.
+        target_gateset (set[str]): (optional) The gateset to compile the circuit to.
             e.g. {"cx", "rx",...}. Defaults to the gateset of the target device, or if none is provided, {"cx", "rz", "rx", "ry", "h"}.
         target_device (qiskit.transpiler.Target): (optional) The target device to compile the circuit for. None if no device to target
         custom_passes (list[qiskit.transpiler.TransformationPass]): (optional) A list of custom passes to apply after the default set
@@ -61,20 +61,19 @@ def compile(
         qiskit_circuit,
     )
 
-    if return_gateset is not None:
+    if target_gateset is not None:
         # Translate into user-defined gateset; no optimization
-        # TODO: Check if the gateset is valid for the target device
         compiled_circuit = qiskit_transpile(
-            compiled_circuit, basis_gates=return_gateset, optimization_level=0
+            compiled_circuit, basis_gates=target_gateset, optimization_level=0
         )
     else:
         try:
             # Use target_device gateset if available
-            return_gateset = target_device.operation_names
+            target_gateset = target_device.operation_names
             # Translate into the target device gateset; no optimization
             compiled_circuit = qiskit_transpile(
                 compiled_circuit,
-                basis_gates=return_gateset,
+                basis_gates=target_gateset,
                 optimization_level=0,
             )
         except AttributeError:

--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -66,18 +66,16 @@ def compile(
         compiled_circuit = qiskit_transpile(
             compiled_circuit, basis_gates=target_gateset, optimization_level=0
         )
-    else:
-        try:
-            # Use target_device gateset if available
-            target_gateset = target_device.operation_names
-            # Translate into the target device gateset; no optimization
-            compiled_circuit = qiskit_transpile(
-                compiled_circuit,
-                basis_gates=target_gateset,
-                optimization_level=0,
-            )
-        except AttributeError:
-            pass  # Use UCC default gateset
+    elif hasattr(target_device, "operation_names"):
+        # Use target_device gateset if available
+        target_gateset = target_device.operation_names
+
+        # Translate into the target device gateset; no optimization
+        compiled_circuit = qiskit_transpile(
+            compiled_circuit,
+            basis_gates=target_gateset,
+            optimization_level=0,
+        )
 
     # Translate the compiled circuit to the desired format
     final_result = translate(compiled_circuit, return_format)

--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -67,6 +67,10 @@ def compile(
             compiled_circuit, basis_gates=target_gateset, optimization_level=0
         )
     elif hasattr(target_device, "operation_names"):
+        if target_gateset not in target_device.operation_names:
+            warnings.warn(
+                f"Warning: The target gateset {target_gateset} is not supported by the target device. "
+            )
         # Use target_device gateset if available
         target_gateset = target_device.operation_names
 

--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -63,6 +63,7 @@ def compile(
 
     if return_gateset is not None:
         # Translate into user-defined gateset; no optimization
+        # TODO: Check if the gateset is valid for the target device
         compiled_circuit = qiskit_transpile(
             compiled_circuit, basis_gates=return_gateset, optimization_level=0
         )

--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -41,7 +41,7 @@ def compile(
         return_format (str): The format in which your circuit will be returned.
             e.g., "TKET", "OpenQASM2". Check ``ucc.supported_circuit_formats()``.
             Defaults to the format of the input circuit.
-        return_gateset (set): (optional) The gateset to compile the circuit to.
+        return_gateset (set[str]): (optional) The gateset to compile the circuit to.
             e.g. {"cx", "rx",...}. Defaults to the gateset of the target device, or if none is provided, {"cx", "rz", "rx", "ry", "h"}.
         target_device (qiskit.transpiler.Target): (optional) The target device to compile the circuit for. None if no device to target
         custom_passes (list[qiskit.transpiler.TransformationPass]): (optional) A list of custom passes to apply after the default set

--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -1,9 +1,8 @@
 from qbraid.programs.alias_manager import get_program_type_alias
 from qbraid.transpiler import ConversionGraph
-from qbraid.transpiler import transpile
-from qiskit.transpiler.passes import BasisTranslator
+from qbraid.transpiler import transpile as translate
 from .transpilers.ucc_defaults import UCCDefault1
-
+from qiskit import transpile as qiskit_transpile
 
 import sys
 import warnings
@@ -54,7 +53,7 @@ def compile(
         return_format = get_program_type_alias(circuit)
 
     # Translate to Qiskit Circuit object
-    qiskit_circuit = transpile(circuit, "qiskit")
+    qiskit_circuit = translate(circuit, "qiskit")
     ucc_default1 = UCCDefault1(target_device=target_device)
     if custom_passes is not None:
         ucc_default1.pass_manager.append(custom_passes)
@@ -63,19 +62,23 @@ def compile(
     )
 
     if return_gateset is not None:
-        # Check if the compiled circuit contains the specified gateset
-        ucc_default1.pass_manager.append(
-            BasisTranslator(target_basis=return_gateset)
+        # Translate into user-defined gateset; no optimization
+        compiled_circuit = qiskit_transpile(
+            compiled_circuit, basis_gates=return_gateset, optimization_level=0
         )
     else:
         try:
+            # Use target_device gateset if available
             return_gateset = target_device.operation_names
-            ucc_default1.pass_manager.append(
-                BasisTranslator(target_basis=return_gateset)
+            # Translate into the target device gateset; no optimization
+            compiled_circuit = qiskit_transpile(
+                compiled_circuit,
+                basis_gates=return_gateset,
+                optimization_level=0,
             )
         except AttributeError:
-            pass  # Use default gateset
+            pass  # Use UCC default gateset
 
     # Translate the compiled circuit to the desired format
-    final_result = transpile(compiled_circuit, return_format)
+    final_result = translate(compiled_circuit, return_format)
     return final_result

--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -1,6 +1,7 @@
 from qbraid.programs.alias_manager import get_program_type_alias
 from qbraid.transpiler import ConversionGraph
 from qbraid.transpiler import transpile
+from qiskit.transpiler.passes import BasisTranslator
 from .transpilers.ucc_defaults import UCCDefault1
 
 
@@ -26,7 +27,11 @@ supported_circuit_formats = ConversionGraph().nodes()
 
 
 def compile(
-    circuit, return_format="original", target_device=None, custom_passes=None
+    circuit,
+    return_format="original",
+    return_gateset=None,
+    target_device=None,
+    custom_passes=None,
 ):
     """Compiles the provided quantum `circuit` by translating it to a Qiskit
     circuit, transpiling it, and returning the optimized circuit in the
@@ -54,6 +59,20 @@ def compile(
     compiled_circuit = ucc_default1.run(
         qiskit_circuit,
     )
+
+    if return_gateset is not None:
+        # Check if the compiled circuit contains the specified gateset
+        ucc_default1.pass_manager.append(
+            BasisTranslator(target_basis=return_gateset)
+        )
+    else:
+        try:
+            return_gateset = target_device.operation_names
+            ucc_default1.pass_manager.append(
+                BasisTranslator(target_basis=return_gateset)
+            )
+        except AttributeError:
+            pass
 
     # Translate the compiled circuit to the desired format
     final_result = transpile(compiled_circuit, return_format)

--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -42,6 +42,8 @@ def compile(
         return_format (str): The format in which your circuit will be returned.
             e.g., "TKET", "OpenQASM2". Check ``ucc.supported_circuit_formats()``.
             Defaults to the format of the input circuit.
+        return_gateset (set): (optional) The gateset to compile the circuit to.
+            e.g. {"cx", "rx",...}. Defaults to the gateset of the target device, or if none is provided, {"cx", "rz", "rx", "ry", "h"}.
         target_device (qiskit.transpiler.Target): (optional) The target device to compile the circuit for. None if no device to target
         custom_passes (list[qiskit.transpiler.TransformationPass]): (optional) A list of custom passes to apply after the default set
 
@@ -72,7 +74,7 @@ def compile(
                 BasisTranslator(target_basis=return_gateset)
             )
         except AttributeError:
-            pass
+            pass  # Use default gateset
 
     # Translate the compiled circuit to the desired format
     final_result = transpile(compiled_circuit, return_format)

--- a/ucc/tests/__init__.py
+++ b/ucc/tests/__init__.py
@@ -1,1 +1,0 @@
-__all__ = ["Mybackend"]

--- a/ucc/tests/__init__.py
+++ b/ucc/tests/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["Mybackend"]

--- a/ucc/tests/mock_backends.py
+++ b/ucc/tests/mock_backends.py
@@ -70,11 +70,4 @@ class Mybackend(Backend):
                     UserWarning,
                     stacklevel=2,
                 )
-        # options = {
-        #     "shots": kwargs.get("shots", self.options.shots),
-        #     "memory": kwargs.get("memory", self.options.shots),
-        # }
-        # job_json = convert_to_wire_format(circuit, options)
-        # job_handle = submit_to_backend(job_jsonb)
-        # return MyJob(self.job_handle, job_json, circuit)
         return None  # Currently not implemented

--- a/ucc/tests/mock_backends.py
+++ b/ucc/tests/mock_backends.py
@@ -1,0 +1,68 @@
+import warnings
+from qiskit.providers import BackendV2 as Backend
+from qiskit.transpiler import Target
+from qiskit.providers import Options
+from qiskit.circuit import Parameter, Measure
+from qiskit.circuit.library import PhaseGate, SXGate, UGate, CXGate, IGate
+
+
+class Mybackend(Backend):
+    """A mock Qiskit backend for testing purposes."""
+
+    def __init__(self):
+        super().__init__()
+
+        # Create Target
+        self._target = Target("Target for My Backend")
+        # Instead of None for this and below instructions you can define
+        # a qiskit.transpiler.InstructionProperties object to define properties
+        # for an instruction.
+        lam = Parameter("λ")
+        p_props = {(qubit,): None for qubit in range(5)}
+        self._target.add_instruction(PhaseGate(lam), p_props)
+        sx_props = {(qubit,): None for qubit in range(5)}
+        self._target.add_instruction(SXGate(), sx_props)
+        phi = Parameter("φ")
+        theta = Parameter("ϴ")
+        u_props = {(qubit,): None for qubit in range(5)}
+        self._target.add_instruction(UGate(theta, phi, lam), u_props)
+        cx_props = {edge: None for edge in [(0, 1), (1, 2), (2, 3), (3, 4)]}
+        self._target.add_instruction(CXGate(), cx_props)
+        meas_props = {(qubit,): None for qubit in range(5)}
+        self._target.add_instruction(Measure(), meas_props)
+        id_props = {(qubit,): None for qubit in range(5)}
+        self._target.add_instruction(IGate(), id_props)
+
+        # Set option validators
+        self.options.set_validator("shots", (1, 4096))
+        self.options.set_validator("memory", bool)
+
+    @property
+    def target(self):
+        return self._target
+
+    @property
+    def max_circuits(self):
+        return 1024
+
+    @classmethod
+    def _default_options(cls):
+        return Options(shots=1024, memory=False)
+
+    def run(self, circuit, **kwargs):
+        # serialize circuits submit to backend and create a job
+        for kwarg in kwargs:
+            if not hasattr(kwarg, self.options):
+                warnings.warn(
+                    "Option %s is not used by this backend" % kwarg,
+                    UserWarning,
+                    stacklevel=2,
+                )
+        # options = {
+        #     "shots": kwargs.get("shots", self.options.shots),
+        #     "memory": kwargs.get("memory", self.options.shots),
+        # }
+        # job_json = convert_to_wire_format(circuit, options)
+        # job_handle = submit_to_backend(job_jsonb)
+        # return MyJob(self.job_handle, job_json, circuit)
+        return None  # Currently not implemented

--- a/ucc/tests/mock_backends.py
+++ b/ucc/tests/mock_backends.py
@@ -7,7 +7,19 @@ from qiskit.circuit.library import PhaseGate, SXGate, UGate, CXGate, IGate
 
 
 class Mybackend(Backend):
-    """A mock Qiskit backend for testing purposes."""
+    """A mock Qiskit backend for testing purposes.
+    Supported operations:
+    - PhaseGate
+    - SXGate
+    - UGate
+    - CXGate
+    - Measure
+    - IGate
+    ['p', 'sx', 'u', 'cx', 'measure', 'id']
+
+    Coupling map:
+    - 0 -- 1 -- 2 -- 3 -- 4
+    """
 
     def __init__(self):
         super().__init__()

--- a/ucc/tests/test_compile.py
+++ b/ucc/tests/test_compile.py
@@ -120,21 +120,15 @@ def test_compile_with_target_device():
         circuit, return_format="original", target_device=t
     )
 
-    dag = circuit_to_dag(result_circuit)
-
     # Check that the gateset is the same as the target device
-    gateset = set()
-    for node in dag.op_nodes():
-        gateset.add(node.op.name)
-
-    # Check that each gate in the compiled gateset is available in the target device
-    for gate in gateset:
-        assert gate in t.operation_names
+    assert set(op.name for op in result_circuit).issubset(t.operation_names)
 
     # Check that the coupling map of the compiled circuit is the same as the target device
     analysis_pass = CheckMap(
         t.build_coupling_map(), property_set_field="check_map"
     )
+
+    dag = circuit_to_dag(result_circuit)
     analysis_pass.run(dag)
     assert analysis_pass.property_set["check_map"]
 
@@ -155,15 +149,7 @@ def test_compile_with_return_gateset():
         return_gateset=return_gateset,
     )
 
-    # Check compilation respected the user's gateset
-    dag = circuit_to_dag(result_circuit)
-    gateset = set()
-    for node in dag.op_nodes():
-        gateset.add(node.op.name)
-
-    # Check that each gate in the compiled gateset is available in the target device
-    for gate in gateset:
-        assert gate in return_gateset
+    assert set(op.name for op in result_circuit).issubset(return_gateset)
 
 
 # TODO: Write a test to check that the user-defined gateset is available in the target device (funcitonality not yet enforced in ucc.compile)

--- a/ucc/tests/test_compile.py
+++ b/ucc/tests/test_compile.py
@@ -120,7 +120,7 @@ def test_compile_with_target_device():
         circuit, return_format="original", target_device=t
     )
 
-    # Check that the gateset is the same as the target device
+    # Check that the gates in the final circuit are all the supported on the target device
     assert set(op.name for op in result_circuit).issubset(t.operation_names)
 
     # Check that the coupling map of the compiled circuit is the same as the target device
@@ -133,33 +133,23 @@ def test_compile_with_target_device():
     assert analysis_pass.property_set["check_map"]
 
 
-def test_compile_with_return_gateset():
+def test_compile_with_target_gateset():
     """Test that the final circuit respects the user-defined gateset, no target device"""
     circuit = QiskitCircuit(2)
     circuit.cx(0, 1)
     circuit.h(0)
 
-    return_gateset = {
+    target_gateset = {
         "ry",
         "rx",
         "cz",
     }
     result_circuit = compile(
         circuit,
-        return_gateset=return_gateset,
+        target_gateset=target_gateset,
     )
 
-    assert set(op.name for op in result_circuit).issubset(return_gateset)
-
-
-# TODO: Write a test to check that the user-defined gateset is available in the target device (funcitonality not yet enforced in ucc.compile)
-# coupling_map = t.build_coupling_map()
-# dag = circuit_to_dag(result_circuit)
-# analysis_pass = CheckMap(
-#     coupling_map, property_set_field="check_map"
-# )
-# analysis_pass.run(dag)
-# assert analysis_pass.property_set["check_map"]
+    assert set(op.name for op in result_circuit).issubset(target_gateset)
 
 
 @pytest.mark.parametrize(
@@ -178,8 +168,6 @@ def test_compilation_retains_gateset(circuit_function, num_qubits, seed):
     assert analysis_pass.property_set["all_gates_in_basis"]
 
 
-# Skip this test
-@pytest.mark.skip(reason="Slow.")
 @pytest.mark.parametrize(
     "circuit_function", [qcnn_circuit, random_clifford_circuit]
 )

--- a/ucc/tests/test_compile.py
+++ b/ucc/tests/test_compile.py
@@ -96,9 +96,8 @@ def test_custom_pass():
 
         def run(self, dag):
             for node in dag.op_nodes():
-                if not isinstance(node.op, HGate):
-                    continue
-                dag.substitute_node(node, XGate())
+                if isinstance(node.op, HGate):
+                    dag.substitute_node(node, XGate())
             return dag
 
     # Example usage with a cirq circuit, stil showcasing the cross-frontend compatibility

--- a/ucc/tests/test_compile.py
+++ b/ucc/tests/test_compile.py
@@ -8,9 +8,8 @@ from qiskit.converters import circuit_to_dag
 from qiskit.quantum_info import Statevector
 from qiskit.transpiler.passes import GatesInBasis
 from qiskit.transpiler.passes.utils import CheckMap
-from qiskit.transpiler import Target
 from qiskit.transpiler.basepasses import TransformationPass
-from qiskit.circuit.library import CXGate, HGate, XGate
+from qiskit.circuit.library import HGate, XGate
 from ucc.tests.mock_backends import Mybackend
 from ucc import compile
 from ucc.transpilers.ucc_defaults import UCCDefault1
@@ -89,36 +88,6 @@ def test_tket_compile():
     assert isinstance(result_circuit, TketCircuit)
 
 
-def test_compile_with_target_device():
-    circuit = QiskitCircuit(3)
-    circuit.cx(0, 1)
-    circuit.cx(0, 2)
-
-    # Create a simple target that does not have direct CX between 0 and 2
-    t = Mybackend().target
-    result_circuit = compile(
-        circuit, return_format="original", target_device=t
-    )
-
-    # Check compilation respected the target device topology
-    dag = circuit_to_dag(result_circuit)
-
-    # Check that the gateset is the same as the target device
-    gateset = set()
-    for node in dag.op_nodes():
-        gateset.add(node.op.name)
-
-    # Check that each gate in the gateset is in the target device
-    for gate in gateset:
-        assert gate in t.operation_names
-
-    analysis_pass = CheckMap(
-        t.build_coupling_map(), property_set_field="check_map"
-    )
-    analysis_pass.run(dag)
-    assert analysis_pass.property_set["check_map"]
-
-
 def test_custom_pass():
     """Verify that a custom pass works with a non-qiskit input circuit"""
 
@@ -141,26 +110,71 @@ def test_custom_pass():
     assert_same_circuits(post_compiler_circuit, CirqCircuit(X(qubit)))
 
 
-def test_return_gateset():
-    """Test that the gateset is returned correctly"""
-    circuit = QiskitCircuit(2)
+def test_compile_with_target_device():
+    circuit = QiskitCircuit(3)
     circuit.cx(0, 1)
-    circuit.h(0)
+    circuit.cx(0, 2)
 
     # Create a simple target that does not have direct CX between 0 and 2
-    t = Target(description="Fake device", num_qubits=3)
-    t.add_instruction(CXGate(), {(0, 1): None, (1, 2): None})
+    t = Mybackend().target
     result_circuit = compile(
-        circuit, return_format="original", return_gateset={"cx", "h"}
+        circuit, return_format="original", target_device=t
     )
 
-    # Check compilation respected the target device topology
     dag = circuit_to_dag(result_circuit)
+
+    # Check that the gateset is the same as the target device
+    gateset = set()
+    for node in dag.op_nodes():
+        gateset.add(node.op.name)
+
+    # Check that each gate in the compiled gateset is available in the target device
+    for gate in gateset:
+        assert gate in t.operation_names
+
+    # Check that the coupling map of the compiled circuit is the same as the target device
     analysis_pass = CheckMap(
         t.build_coupling_map(), property_set_field="check_map"
     )
     analysis_pass.run(dag)
     assert analysis_pass.property_set["check_map"]
+
+
+def test_return_gateset():
+    """Test that the final circuit respects the user-defined gateset, no target device"""
+    circuit = QiskitCircuit(2)
+    circuit.cx(0, 1)
+    circuit.h(0)
+
+    return_gateset = {
+        "ry",
+        "rx",
+        "cz",
+    }
+    result_circuit = compile(
+        circuit,
+        return_gateset=return_gateset,
+    )
+
+    # Check compilation respected the user's gateset
+    dag = circuit_to_dag(result_circuit)
+    gateset = set()
+    for node in dag.op_nodes():
+        gateset.add(node.op.name)
+
+    # Check that each gate in the compiled gateset is available in the target device
+    for gate in gateset:
+        assert gate in return_gateset
+
+
+# TODO: Write a test to check that the user-defined gateset is available in the target device (funcitonality not yet enforced in ucc.compile)
+# coupling_map = t.build_coupling_map()
+# dag = circuit_to_dag(result_circuit)
+# analysis_pass = CheckMap(
+#     coupling_map, property_set_field="check_map"
+# )
+# analysis_pass.run(dag)
+# assert analysis_pass.property_set["check_map"]
 
 
 @pytest.mark.parametrize(

--- a/ucc/tests/test_compile.py
+++ b/ucc/tests/test_compile.py
@@ -11,6 +11,7 @@ from qiskit.transpiler.passes.utils import CheckMap
 from qiskit.transpiler import Target
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.circuit.library import CXGate, HGate, XGate
+from .mock_backends import Mybackend
 from ucc import compile
 from ucc.transpilers.ucc_defaults import UCCDefault1
 import numpy as np
@@ -94,8 +95,7 @@ def test_compile_with_target_device():
     circuit.cx(0, 2)
 
     # Create a simple target that does not have direct CX between 0 and 2
-    t = Target(description="Fake device", num_qubits=3)
-    t.add_instruction(CXGate(), {(0, 1): None, (1, 2): None})
+    t = Mybackend().target
     result_circuit = compile(
         circuit, return_format="original", target_device=t
     )
@@ -129,6 +129,28 @@ def test_custom_pass():
 
     post_compiler_circuit = compile(cirq_circuit, custom_passes=[HtoX()])
     assert_same_circuits(post_compiler_circuit, CirqCircuit(X(qubit)))
+
+
+def test_return_gateset():
+    """Test that the gateset is returned correctly"""
+    circuit = QiskitCircuit(2)
+    circuit.cx(0, 1)
+    circuit.h(0)
+
+    # Create a simple target that does not have direct CX between 0 and 2
+    t = Target(description="Fake device", num_qubits=3)
+    t.add_instruction(CXGate(), {(0, 1): None, (1, 2): None})
+    result_circuit = compile(
+        circuit, return_format="original", return_gateset={"cx", "h"}
+    )
+
+    # Check compilation respected the target device topology
+    dag = circuit_to_dag(result_circuit)
+    analysis_pass = CheckMap(
+        t.build_coupling_map(), property_set_field="check_map"
+    )
+    analysis_pass.run(dag)
+    assert analysis_pass.property_set["check_map"]
 
 
 @pytest.mark.parametrize(

--- a/ucc/tests/test_compile.py
+++ b/ucc/tests/test_compile.py
@@ -108,24 +108,31 @@ def test_custom_pass():
     post_compiler_circuit = compile(cirq_circuit, custom_passes=[HtoX()])
     assert_same_circuits(post_compiler_circuit, CirqCircuit(X(qubit)))
 
+    def test_compile_target_device_opset():
+        circuit = QiskitCircuit(3)
+        circuit.cx(0, 1)
+        circuit.cx(0, 2)
 
-@pytest.mark.parametrize("check", ["opset", "coupling_map"])
-def test_compile_with_target_device(check):
-    circuit = QiskitCircuit(3)
-    circuit.cx(0, 1)
-    circuit.cx(0, 2)
-
-    # Create a simple target that does not have direct CX between 0 and 2
-    t = Mybackend().target
-    result_circuit = compile(
-        circuit, return_format="original", target_device=t
-    )
-    if check == "opset":
-        # Check that the gates in the final circuit are all the supported on the target device
+        # Create a simple target that does not have direct CX between 0 and 2
+        t = Mybackend().target
+        result_circuit = compile(
+            circuit, return_format="original", target_device=t
+        )
+        # Check that the gates in the final circuit are all supported on the target device
         assert set(op.name for op in result_circuit).issubset(
             t.operation_names
         )
-    elif check == "coupling_map":
+
+    def test_compile_target_device_coupling_map():
+        circuit = QiskitCircuit(3)
+        circuit.cx(0, 1)
+        circuit.cx(0, 2)
+
+        # Create a simple target that does not have direct CX between 0 and 2
+        t = Mybackend().target
+        result_circuit = compile(
+            circuit, return_format="original", target_device=t
+        )
         # Check that the compiled circuit respects the coupling map of the target device
         analysis_pass = CheckMap(
             t.build_coupling_map(), property_set_field="check_map"

--- a/ucc/tests/test_compile.py
+++ b/ucc/tests/test_compile.py
@@ -11,7 +11,7 @@ from qiskit.transpiler.passes.utils import CheckMap
 from qiskit.transpiler import Target
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.circuit.library import CXGate, HGate, XGate
-from .mock_backends import Mybackend
+from ucc.tests.mock_backends import Mybackend
 from ucc import compile
 from ucc.transpilers.ucc_defaults import UCCDefault1
 import numpy as np
@@ -102,6 +102,16 @@ def test_compile_with_target_device():
 
     # Check compilation respected the target device topology
     dag = circuit_to_dag(result_circuit)
+
+    # Check that the gateset is the same as the target device
+    gateset = set()
+    for node in dag.op_nodes():
+        gateset.add(node.op.name)
+
+    # Check that each gate in the gateset is in the target device
+    for gate in gateset:
+        assert gate in t.operation_names
+
     analysis_pass = CheckMap(
         t.build_coupling_map(), property_set_field="check_map"
     )
@@ -169,6 +179,8 @@ def test_compilation_retains_gateset(circuit_function, num_qubits, seed):
     assert analysis_pass.property_set["all_gates_in_basis"]
 
 
+# Skip this test
+@pytest.mark.skip(reason="Slow.")
 @pytest.mark.parametrize(
     "circuit_function", [qcnn_circuit, random_clifford_circuit]
 )

--- a/ucc/tests/test_compile.py
+++ b/ucc/tests/test_compile.py
@@ -140,7 +140,7 @@ def test_compile_with_target_device():
     assert analysis_pass.property_set["check_map"]
 
 
-def test_return_gateset():
+def test_compile_with_return_gateset():
     """Test that the final circuit respects the user-defined gateset, no target device"""
     circuit = QiskitCircuit(2)
     circuit.cx(0, 1)

--- a/ucc/tests/test_compile.py
+++ b/ucc/tests/test_compile.py
@@ -109,7 +109,8 @@ def test_custom_pass():
     assert_same_circuits(post_compiler_circuit, CirqCircuit(X(qubit)))
 
 
-def test_compile_with_target_device():
+@pytest.mark.parametrize("check", ["opset", "coupling_map"])
+def test_compile_with_target_device(check):
     circuit = QiskitCircuit(3)
     circuit.cx(0, 1)
     circuit.cx(0, 2)
@@ -119,18 +120,20 @@ def test_compile_with_target_device():
     result_circuit = compile(
         circuit, return_format="original", target_device=t
     )
+    if check == "opset":
+        # Check that the gates in the final circuit are all the supported on the target device
+        assert set(op.name for op in result_circuit).issubset(
+            t.operation_names
+        )
+    elif check == "coupling_map":
+        # Check that the compiled circuit respects the coupling map of the target device
+        analysis_pass = CheckMap(
+            t.build_coupling_map(), property_set_field="check_map"
+        )
 
-    # Check that the gates in the final circuit are all the supported on the target device
-    assert set(op.name for op in result_circuit).issubset(t.operation_names)
-
-    # Check that the coupling map of the compiled circuit is the same as the target device
-    analysis_pass = CheckMap(
-        t.build_coupling_map(), property_set_field="check_map"
-    )
-
-    dag = circuit_to_dag(result_circuit)
-    analysis_pass.run(dag)
-    assert analysis_pass.property_set["check_map"]
+        dag = circuit_to_dag(result_circuit)
+        analysis_pass.run(dag)
+        assert analysis_pass.property_set["check_map"]
 
 
 def test_compile_with_target_gateset():


### PR DESCRIPTION
The fix I went for was to allow users to pass 
1) a `return_gateset` in the form of `dict` keys (or a set) and use the `qiskit.transpile(circuit, basis_gates={'my', 'gate', 'set'}, optimization=0)` functionality to convert to a new basis automatically OR
2) a `target_device` whose allowable operations will be checked if that is an attribute present in that device. 

Added tests to confirm that the user-defined gateset is respected when it is passed, and the same for the target device.

**Note:** there is currently no functionality to check that a user-defined gateset is a) universal or b) available on the target_device, but currently these will cause errors that are reasonably straightforward to interpret for the user ('this operation is not available on this target'), so I think we can leave that for a future issue.
