### PR TITLE
Separate dependency updates in auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,13 @@
+# .github/release.yml
+
+changelog:
+  categories:
+    - title: 🏕 Features
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: 👒 Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
Now that we have Dependabot running, I though it would be nice to separate the dependency updates from other updates as part of the auto-generated release notes. This just copies the [setup in the Github docs](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes) for separating those by default.