### PR TITLE
Allow triggering benchmark comparision on fork PRs

### DIFF
--- a/.github/workflows/trigger-ucc-bench-pr.yml
+++ b/.github/workflows/trigger-ucc-bench-pr.yml
@@ -9,10 +9,15 @@
 # so it could trigger the workflow. See
 # https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions
 # for details.
+#
+# NOTE - This uses the `pull_request_target` event, which runs in the context of the base branch rather than the PR branch.
+# This means we can run on PRs initiated from forks. It's best practice to *not* run or checkout any code from the fork
+# however, as it might contain malicious code. So this job only kicks off the ucc-bench workflow.
+
 
 name: Trigger ucc PR workflow in ucc-bench
 on:
-    pull_request:
+    pull_request_target:
       branches:
         - main
       types:
@@ -23,7 +28,7 @@ on:
 jobs:
   trigger-benchmarks-pr:
     runs-on: ubuntu-latest
-    # Don't run on forks or original benchmark commits
+    # Only run if label is present
     if: contains(github.event.pull_request.labels.*.name, 'preview-benchmark-results')
 
     steps:


### PR DESCRIPTION
This is a companion to https://github.com/unitaryfoundation/ucc-bench/pull/69, and switches the workflow trigger to `pull_request_target` for the benchmark PR comparison runs. This should enable PRs with the `preview-benchmark-results` label that are coming from forks to run the benchmarks.