### PR TITLE
Add section to docs on research using UCC

### DIFF
--- a/.github/ISSUE_TEMPLATE/research_reference.md
+++ b/.github/ISSUE_TEMPLATE/research_reference.md
@@ -1,0 +1,13 @@
+---
+name: Research reference
+about: Add a summary of and link to research that used UCC
+title: ''
+labels: 'documentation'
+assignees: ''
+---
+
+Have you used UCC in a research project? Fantastic! Please add an entry for your paper or code to our docs so that others can discover it too.
+
+[ ] **Add the BibTeX entry** for your reference to [`docs/source/refs.bib`](../docs/source/refs.bib).
+[ ] **Add a summary and citation key** to [`docs/source/research_references.rst`](../docs/source/research_references.rst), following the existing conventions in the file, and briefly sharing the research and you used UCC.
+[ ] **Open a pull request** with your changes to resolve this issue.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 [![Documentation Status](https://readthedocs.org/projects/ucc/badge/?version=latest)](https://ucc.readthedocs.io/en/latest/?badge=latest)
 [![Discord Chat](https://img.shields.io/badge/dynamic/json?color=blue&label=Discord&query=approximate_presence_count&suffix=%20online.&url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FJqVGmpkP96%3Fwith_counts%3Dtrue)](http://discord.unitary.foundation)
 
-
+<!-- start-changelog-link-to-remove-for-docs -->
 **[See the changelog](./CHANGELOG.md)**
+<!-- end-changelog-link-to-remove-for-docs -->
 
 The **Unitary Compiler Collection (UCC)** is a Python library for frontend-agnostic, high performance compilation of quantum circuits. UCC's goal is to gather together the best of open source compilation to make quantum programming simpler, faster, and more scalable.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,10 +6,11 @@ sys.path.insert(0, os.path.abspath("../../"))
 sys.path.insert(0, os.path.abspath("../../../"))
 
 from ucc._version import __version__
-
+from datetime import datetime
 
 project = "ucc"
-copyright = "2024, Unitary Foundation"
+current_year = datetime.now().year
+copyright = f"2024–{current_year}, Unitary Foundation"
 author = "Unitary Foundation"
 directory_of_this_file = os.path.dirname(os.path.abspath(__file__))
 release = __version__
@@ -22,7 +23,10 @@ extensions = [
     "sphinx.ext.autodoc",
     "myst_parser",
     "sphinx.ext.doctest",
+    "sphinxcontrib.bibtex",
 ]
+
+bibtex_bibfiles = ["refs.bib"]
 
 myst_enable_extensions = [
     "linkify",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,6 +3,12 @@ Welcome to the docs!
 
 .. include:: ../../README.md
    :parser: myst_parser.sphinx_
+   :end-before: <!-- start-changelog-link-to-remove-for-docs -->
+
+
+.. include:: ../../README.md
+   :parser: myst_parser.sphinx_
+   :start-after: <!-- end-changelog-link-to-remove-for-docs -->
    :end-before: <!-- start-how-does-ucc-stack-up -->
 
 .. include:: ../../README.md
@@ -19,6 +25,7 @@ Welcome to the docs!
    Benchmarking <benchmarking.rst>
    Developer Documentation <dev.rst>
    Code of Conduct <CODE_OF_CONDUCT.rst>
+   Research References <research_references.rst>
 
 
 

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1,0 +1,9 @@
+@misc{Du:2025dld,
+    author = "Du, Zefan and Kan, Shuwen and Stein, Samuel and Liang, Zhiding and Li, Ang and Mao, Ying",
+    title = "{Hardware-aware Compilation for Chip-to-Chip Coupler-Connected Modular Quantum Systems}",
+    eprint = "2505.09036",
+    archivePrefix = "arXiv",
+    primaryClass = "quant-ph",
+    month = "5",
+    year = "2025"
+}

--- a/docs/source/research_references.rst
+++ b/docs/source/research_references.rst
@@ -1,0 +1,14 @@
+Research References
+======================
+
+This page lists research papers that have used the Unitary Computing Compiler (UCC) in their work.
+If you have used UCC in your research, please let us know by `opening an issue or pull request <https://github.com/unitaryfoundation/ucc/issues/new?template=research_reference.md>`_ on GitHub to update this list.
+If you are interested in using UCC for your research, please check out the `user guide <user_guide.rst>`_ and `contributing guide <contributing.rst>`_.
+
+- :cite:t:`Du:2025dld` introduce CCMap, a modular circuit compiler designed for chip-to-chip coupler-connected quantum systems.
+  CCMap improves the fidelity of circuits compiled by reducing costly inter-chip operations and applying noise-aware mapping.
+  The authors benchmark their framework by integrating it with several existing compilers,including UCC, and demonstrate that CCMap enhances UCC's performance.
+  UCC-CCMap achieved up to **17.8% higher fidelity** and **significant reductions in compilation cost** compared to UCC alone.
+
+.. bibliography::
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ docs = [
     "sphinx>=8.1.3",
     "myst-parser>=0.15",
     "linkify-it-py>=2.0.3",
+    "sphinxcontrib-bibtex>=2.6.3",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -407,6 +407,15 @@ wheels = [
 ]
 
 [[package]]
+name = "latexcodec"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/e7/ed339caf3662976949e4fdbfdf4a6db818b8d2aa1cf2b5f73af89e936bba/latexcodec-3.0.0.tar.gz", hash = "sha256:917dc5fe242762cc19d963e6548b42d63a118028cdd3361d62397e3b638b6bc5", size = 31023, upload_time = "2024-03-06T14:51:39.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/bf/ea8887e9f31a8f93ca306699d11909c6140151393a4216f0d9f85a004077/latexcodec-3.0.0-py3-none-any.whl", hash = "sha256:6f3477ad5e61a0a99bd31a6a370c34e88733a6bad9c921a3ffcfacada12f41a7", size = 18150, upload_time = "2024-03-06T14:51:37.872Z" },
+]
+
+[[package]]
 name = "linkify-it-py"
 version = "2.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -762,6 +771,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pybtex"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "latexcodec" },
+    { name = "pyyaml" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/9b/fd39836a6397fb363446d83075a7b9c2cc562f4c449292e039ed36084376/pybtex-0.24.0.tar.gz", hash = "sha256:818eae35b61733e5c007c3fcd2cfb75ed1bc8b4173c1f70b56cc4c0802d34755", size = 402879, upload_time = "2021-01-17T20:02:27.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/5f/40d8e90f985a05133a8895fc454c6127ecec3de8b095dd35bba91382f803/pybtex-0.24.0-py2.py3-none-any.whl", hash = "sha256:e1e0c8c69998452fea90e9179aa2a98ab103f3eed894405b7264e517cc2fcc0f", size = 561354, upload_time = "2021-01-17T20:02:23.696Z" },
+]
+
+[[package]]
+name = "pybtex-docutils"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "pybtex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/84/796ea94d26188a853660f81bded39f8de4cfe595130aef0dea1088705a11/pybtex-docutils-1.0.3.tar.gz", hash = "sha256:3a7ebdf92b593e00e8c1c538aa9a20bca5d92d84231124715acc964d51d93c6b", size = 18348, upload_time = "2023-08-22T18:47:54.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/b1/ce1f4596211efb5410e178a803f08e59b20bedb66837dcf41e21c54f9ec1/pybtex_docutils-1.0.3-py3-none-any.whl", hash = "sha256:8fd290d2ae48e32fcb54d86b0efb8d573198653c7e2447d5bec5847095f430b9", size = 6385, upload_time = "2023-08-22T06:43:20.513Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.3"
 source = { registry = "https://pypi.org/simple" }
@@ -912,11 +948,11 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/1d/9ff68a230d627e196aa64b9cc8efc37423c5bfaff74c0b00509e4a7dadfe/pytket-2.5.0-cp312-abi3-macosx_13_0_arm64.whl", hash = "sha256:4cacdd72a81424b6f9004f548976f5da32b71b93ca43a6d22bf2168691160c24", size = 5593630, upload-time = "2025-06-02T13:07:44.591Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/1f/a2ef37ab2897b31e04904f2b3626b9e44f00eec434c59e739dc149d52b4b/pytket-2.5.0-cp312-abi3-macosx_13_0_x86_64.whl", hash = "sha256:23da4f587b4a7593404859b228572bff0a88627b333706100989a9f43851f438", size = 6323836, upload-time = "2025-06-02T13:07:46.459Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/70/761130f4e1aa95f771a3473bac74f60da921257057905a435cdc4932e0c2/pytket-2.5.0-cp312-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:755cccb2a9e93889aa7163a8291d1bcdaf38d6f376cd0a67677717d96213a8ec", size = 7478039, upload-time = "2025-06-02T13:07:48.084Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/48/e2c0f1b1db098b174dd89586a9213d2767a2945cebfaf5e5bebf5edb8a08/pytket-2.5.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4eaf16b131af21f85403d92ed337f9e36a1632101ed1059f7dbf2924f4f57af9", size = 8130898, upload-time = "2025-06-02T13:07:50.268Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/f4/aa2a7d450343f7c020ed4cc9f23b420348b3e0d1fe233fbfe890572898c8/pytket-2.5.0-cp312-abi3-win_amd64.whl", hash = "sha256:ac15b2ab7e59d72fe2a1e47991e533a25ba3a619ffaf2acfb131c98128ad61f0", size = 9662616, upload-time = "2025-06-02T13:07:52.505Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1d/9ff68a230d627e196aa64b9cc8efc37423c5bfaff74c0b00509e4a7dadfe/pytket-2.5.0-cp312-abi3-macosx_13_0_arm64.whl", hash = "sha256:4cacdd72a81424b6f9004f548976f5da32b71b93ca43a6d22bf2168691160c24", size = 5593630, upload_time = "2025-06-02T13:07:44.591Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/1f/a2ef37ab2897b31e04904f2b3626b9e44f00eec434c59e739dc149d52b4b/pytket-2.5.0-cp312-abi3-macosx_13_0_x86_64.whl", hash = "sha256:23da4f587b4a7593404859b228572bff0a88627b333706100989a9f43851f438", size = 6323836, upload_time = "2025-06-02T13:07:46.459Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/70/761130f4e1aa95f771a3473bac74f60da921257057905a435cdc4932e0c2/pytket-2.5.0-cp312-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:755cccb2a9e93889aa7163a8291d1bcdaf38d6f376cd0a67677717d96213a8ec", size = 7478039, upload_time = "2025-06-02T13:07:48.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/48/e2c0f1b1db098b174dd89586a9213d2767a2945cebfaf5e5bebf5edb8a08/pytket-2.5.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4eaf16b131af21f85403d92ed337f9e36a1632101ed1059f7dbf2924f4f57af9", size = 8130898, upload_time = "2025-06-02T13:07:50.268Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f4/aa2a7d450343f7c020ed4cc9f23b420348b3e0d1fe233fbfe890572898c8/pytket-2.5.0-cp312-abi3-win_amd64.whl", hash = "sha256:ac15b2ab7e59d72fe2a1e47991e533a25ba3a619ffaf2acfb131c98128ad61f0", size = 9662616, upload_time = "2025-06-02T13:07:52.505Z" },
 ]
 
 [[package]]
@@ -1001,15 +1037,15 @@ dependencies = [
     { name = "sympy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/e7/db26a543ce3fe57e1f239e8d5015ec04db53c5801362f1bd2e893a69c99f/qiskit-2.0.2.tar.gz", hash = "sha256:4901496df2d891c8b1b3d79f5b255da6343153cc7dcee1e2caae95be58b8b354", size = 3392590, upload-time = "2025-05-27T20:41:25.824Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/e7/db26a543ce3fe57e1f239e8d5015ec04db53c5801362f1bd2e893a69c99f/qiskit-2.0.2.tar.gz", hash = "sha256:4901496df2d891c8b1b3d79f5b255da6343153cc7dcee1e2caae95be58b8b354", size = 3392590, upload_time = "2025-05-27T20:41:25.824Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/4f/4c35b2aae7aa0d90214b72b7db588c1952e89d99769e053f044cde539842/qiskit-2.0.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:93e357614eb06277c9dbce9a2ad3b9ebb966402e1f91cea06129f9ddf593247b", size = 6336021, upload-time = "2025-05-27T20:41:14.177Z" },
-    { url = "https://files.pythonhosted.org/packages/65/a4/a97894c2b114e60da2bbeac4fbe57b14e1cee5d5de5701e7ddafea9635ad/qiskit-2.0.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:07e380069fa4f10ab3082322aa76c866d3ac61b125a7a1d8eb084425d77aa4f1", size = 5940688, upload-time = "2025-05-27T20:41:17.51Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/bd/efac47348d2ae2321163989af54f24601495fd36d17f8b15fccfd05d1052/qiskit-2.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce89ee741463241a0ab0f2a0f68cba2850d00038b25df445b9190668c8961015", size = 6509615, upload-time = "2025-05-27T20:41:20.093Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/dc/412a4becbd97abe07616185339d36952d477ff695cf76919a668d0235ca9/qiskit-2.0.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a6f9b8aca280018dc42abd601df862f3444a1ca4863a85571260a8464c279174", size = 6738875, upload-time = "2025-05-27T22:14:37.01Z" },
-    { url = "https://files.pythonhosted.org/packages/93/cb/80ee7d6d704f837b791fbbe952434d113739c000e3ec445e7055e3bd844c/qiskit-2.0.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e2422c375cd1cbe2ff8f5b59361479a50c1df1b99ff6a29738bf744a41039dc1", size = 6493706, upload-time = "2025-05-27T22:14:39.562Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/7c/f04c4c6ab93b359fb6ddd9090b8ababa43caa4f4aba4e0a45bd9d85f0680/qiskit-2.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e7a52120623788768234fdc47f9c48cb0523f0cb66bb5408c1bc39048007f15", size = 6505135, upload-time = "2025-05-27T20:41:21.782Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/6b/af910210ba1642281990d078f1281784173068c59a81e7fce9982cf98ddf/qiskit-2.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:1764e40a4cf570ad30384c5c530a65c7765062c8e1ac50122b47d863ae8f5376", size = 6243174, upload-time = "2025-05-27T20:41:23.514Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4f/4c35b2aae7aa0d90214b72b7db588c1952e89d99769e053f044cde539842/qiskit-2.0.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:93e357614eb06277c9dbce9a2ad3b9ebb966402e1f91cea06129f9ddf593247b", size = 6336021, upload_time = "2025-05-27T20:41:14.177Z" },
+    { url = "https://files.pythonhosted.org/packages/65/a4/a97894c2b114e60da2bbeac4fbe57b14e1cee5d5de5701e7ddafea9635ad/qiskit-2.0.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:07e380069fa4f10ab3082322aa76c866d3ac61b125a7a1d8eb084425d77aa4f1", size = 5940688, upload_time = "2025-05-27T20:41:17.51Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/bd/efac47348d2ae2321163989af54f24601495fd36d17f8b15fccfd05d1052/qiskit-2.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce89ee741463241a0ab0f2a0f68cba2850d00038b25df445b9190668c8961015", size = 6509615, upload_time = "2025-05-27T20:41:20.093Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/dc/412a4becbd97abe07616185339d36952d477ff695cf76919a668d0235ca9/qiskit-2.0.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a6f9b8aca280018dc42abd601df862f3444a1ca4863a85571260a8464c279174", size = 6738875, upload_time = "2025-05-27T22:14:37.01Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cb/80ee7d6d704f837b791fbbe952434d113739c000e3ec445e7055e3bd844c/qiskit-2.0.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e2422c375cd1cbe2ff8f5b59361479a50c1df1b99ff6a29738bf744a41039dc1", size = 6493706, upload_time = "2025-05-27T22:14:39.562Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7c/f04c4c6ab93b359fb6ddd9090b8ababa43caa4f4aba4e0a45bd9d85f0680/qiskit-2.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e7a52120623788768234fdc47f9c48cb0523f0cb66bb5408c1bc39048007f15", size = 6505135, upload_time = "2025-05-27T20:41:21.782Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6b/af910210ba1642281990d078f1281784173068c59a81e7fce9982cf98ddf/qiskit-2.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:1764e40a4cf570ad30384c5c530a65c7765062c8e1ac50122b47d863ae8f5376", size = 6243174, upload_time = "2025-05-27T20:41:23.514Z" },
 ]
 
 [[package]]
@@ -1219,6 +1255,22 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinxcontrib-bibtex"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "pybtex" },
+    { name = "pybtex-docutils" },
+    { name = "setuptools" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/ce/054a8ec04063f9a27772fea7188f796edbfa382e656d3b76428323861f0e/sphinxcontrib_bibtex-2.6.3.tar.gz", hash = "sha256:7c790347ef1cb0edf30de55fc324d9782d085e89c52c2b8faafa082e08e23946", size = 117177, upload_time = "2024-09-12T14:23:44.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/49/c23f9493c0a5d5881fb7ed3002e87708454fef860aa96a48e755d27bf6f0/sphinxcontrib_bibtex-2.6.3-py3-none-any.whl", hash = "sha256:ff016b738fcc867df0f75c29e139b3b2158d26a2c802db27963cb128be3b75fb", size = 40340, upload_time = "2024-09-12T14:23:43.593Z" },
+]
+
+[[package]]
 name = "sphinxcontrib-devhelp"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1387,6 +1439,7 @@ docs = [
     { name = "linkify-it-py" },
     { name = "myst-parser" },
     { name = "sphinx" },
+    { name = "sphinxcontrib-bibtex" },
 ]
 
 [package.metadata]
@@ -1410,6 +1463,7 @@ docs = [
     { name = "linkify-it-py", specifier = ">=2.0.3" },
     { name = "myst-parser", specifier = ">=0.15" },
     { name = "sphinx", specifier = ">=8.1.3" },
+    { name = "sphinxcontrib-bibtex", specifier = ">=2.6.3" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves #388 by adding a dedicated page to the docs to summarize and link out to uses of UCC. The flow is to add a bibtex entry into a new `refs.bib` file, then add a summary which cites that in the documentation file. It's a little overboard for now, but felt it would be better over time to make formatting consistent and to have a portable set of references.

I also added an issue template to walk users through doing this in the future.