### PR TITLE
Fix links to research references in docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/research_reference.md
+++ b/.github/ISSUE_TEMPLATE/research_reference.md
@@ -8,6 +8,6 @@ assignees: ''
 
 Have you used UCC in a research project? Fantastic! Please add an entry for your paper or code to our docs so that others can discover it too.
 
-[ ] **Add the BibTeX entry** for your reference to [`docs/source/refs.bib`](../docs/source/refs.bib).
-[ ] **Add a summary and citation key** to [`docs/source/research_references.rst`](../docs/source/research_references.rst), following the existing conventions in the file, and briefly sharing the research and you used UCC.
+[ ] **Add the BibTeX entry** for your reference to [`docs/source/refs.bib`](../../docs/source/refs.bib).
+[ ] **Add a summary and citation key** to [`docs/source/research_references.rst`](../../docs/source/research_references.rst), following the existing conventions in the file, and briefly sharing the research and you used UCC.
 [ ] **Open a pull request** with your changes to resolve this issue.


### PR DESCRIPTION
The previous links were missing a ../ in the relative path