### PR TITLE
Simplified and optimized logic for target gateset selection. 

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -81,9 +81,9 @@ UCC settings can be adjusted using the keyword arguments of the ``ucc.compile()`
 
 
 - ``return_format`` is the format in which the input circuit will be returned, e.g. "TKET" or "OpenQASM2". Check ``ucc.supported_circuit_formats`` for supported circuit formats. Default is the format of input circuit.
-- ``target_gateset`` is the gateset to compile the circuit to, e.g. {"cx", "rx",...}. Defaults to the gateset of the target device. If none is provided, the basis gates of the input circuit are not changed.
-- ``target_device`` can be specified as a Qiskit backend or coupling map, or a list of connections between qubits. If None, all-to-all connectivity is assumed. If a Qiskit backend or coupling map is specified, only the coupling list extracted from the backend is used.
-- ``custom_passes`` can be a list of Qiskit ``TransformationPass`` to run after the default set of passes in ``UCCDefault1``.
+- ``target_gateset`` is the gateset to compile the circuit to, e.g. {"cx", "rx",...}. Defaults to the gateset of the target device. If none is provided, defaults to `{"cx", "rz", "rx", "ry", "h"}`.
+- ``target_device`` can be specified as a Qiskit backend. If None, all-to-all connectivity is assumed. If a `target_device` is specified, `target_device.operation_names` supercedes the `target_gateset`.
+- ``custom_passes`` can be a list of Qiskit ``TransformationPass`` objects to run after the default set of passes in ``UCCDefault1``.
 
 Writing a custom pass
 =====================

--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -1,6 +1,7 @@
 from qbraid.programs.alias_manager import get_program_type_alias
 from qbraid.transpiler import ConversionGraph
 from qbraid.transpiler import transpile as translate
+from qiskit import transpile as qiskit_transpile
 from .transpilers.ucc_defaults import UCCDefault1
 
 import sys
@@ -63,11 +64,11 @@ def compile(
     )
 
     # Translate into the target device gateset first; no optimization
-    basis_translated_circuit = qiskit_circuit  # qiskit_transpile(
-    #     qiskit_circuit,
-    #     basis_gates=ucc_default1.target_gateset,
-    #     optimization_level=0,
-    # )
+    basis_translated_circuit = qiskit_transpile(
+        qiskit_circuit,
+        basis_gates=ucc_default1.target_gateset,
+        optimization_level=0,
+    )
 
     if custom_passes is not None:
         ucc_default1.pass_manager.append(custom_passes)

--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -42,11 +42,11 @@ def compile(
             e.g., "TKET", "OpenQASM2". Check ``ucc.supported_circuit_formats``.
             Defaults to the format of the input circuit.
         target_gateset (set[str]): (optional) The gateset to compile the circuit to.
-            e.g. {"cx", "rx",...}. Defaults to the gate set of the target device if
-            available. If no `target_gateset` or ` target_device` is provided, the
-            basis gates of the input circuit are not changed.
-        target_device (qiskit.transpiler.Target): (optional) The target device to compile the circuit for. None if no device to target
-        custom_passes (list[qiskit.transpiler.TransformationPass]): (optional) A list of custom passes to apply after the default set
+            e.g. {"cx", "rx",...}. Defaults to the gate set of the target device if available. If no `target_gateset` or ` target_device` is provided, defaults to `{"cx", "rz", "rx", "ry", "h"}`.
+        target_device (qiskit.transpiler.Target): (optional)
+            The target device  to compile the circuit for. Can be specified as a Qiskit backend. If None, all-to-all connectivity is assumed. If a `target_device` is specified, `target_device.operation_names` supercedes the `target_gateset`.
+        custom_passes (list[qiskit.transpiler.TransformationPass]): (optional)
+            A list of custom passes to apply after the default set
             of passes. Defaults to None.
 
     Returns:
@@ -58,30 +58,23 @@ def compile(
     # Translate to Qiskit Circuit object
     qiskit_circuit = translate(circuit, "qiskit")
 
-    ucc_default1 = UCCDefault1(target_device=target_device)
+    # Initialize the UCCDefault1 compiler with the target device and gateset
+    ucc_default1 = UCCDefault1(
+        target_device=target_device, target_gateset=target_gateset
+    )
+
+    # Translate into the target device gateset first; no optimization
+    basis_translated_circuit = qiskit_transpile(
+        qiskit_circuit,
+        basis_gates=ucc_default1.target_gateset,
+        optimization_level=0,
+    )
+
     if custom_passes is not None:
         ucc_default1.pass_manager.append(custom_passes)
-    compiled_circuit = ucc_default1.run(qiskit_circuit)
 
-    if target_gateset is not None:
-        # Translate into user-defined gateset; no optimization
-        compiled_circuit = qiskit_transpile(
-            compiled_circuit, basis_gates=target_gateset, optimization_level=0
-        )
-    elif hasattr(target_device, "operation_names"):
-        if target_gateset not in target_device.operation_names:
-            warnings.warn(
-                f"Warning: The target gateset {target_gateset} is not supported by the target device. "
-            )
-        # Use target_device gateset if available
-        target_gateset = target_device.operation_names
-
-        # Translate into the target device gateset; no optimization
-        compiled_circuit = qiskit_transpile(
-            compiled_circuit,
-            basis_gates=target_gateset,
-            optimization_level=0,
-        )
+    # Compile the circuit using the UCCDefault1 pass manager
+    compiled_circuit = ucc_default1.run(basis_translated_circuit)
 
     # Translate the compiled circuit to the desired format
     final_result = translate(compiled_circuit, return_format)

--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -2,7 +2,6 @@ from qbraid.programs.alias_manager import get_program_type_alias
 from qbraid.transpiler import ConversionGraph
 from qbraid.transpiler import transpile as translate
 from .transpilers.ucc_defaults import UCCDefault1
-from qiskit import transpile as qiskit_transpile
 
 import sys
 import warnings
@@ -64,11 +63,11 @@ def compile(
     )
 
     # Translate into the target device gateset first; no optimization
-    basis_translated_circuit = qiskit_transpile(
-        qiskit_circuit,
-        basis_gates=ucc_default1.target_gateset,
-        optimization_level=0,
-    )
+    basis_translated_circuit = qiskit_circuit  # qiskit_transpile(
+    #     qiskit_circuit,
+    #     basis_gates=ucc_default1.target_gateset,
+    #     optimization_level=0,
+    # )
 
     if custom_passes is not None:
         ucc_default1.pass_manager.append(custom_passes)

--- a/ucc/tests/test_compile.py
+++ b/ucc/tests/test_compile.py
@@ -165,6 +165,21 @@ def test_custom_pass():
         assert analysis_pass.property_set["check_map"]
 
 
+def test_compile_with_no_target_gateset_or_device():
+    """Test that the final circuit is in the default gateset if no `target_gateset` or `target_device` is provided."""
+    circuit = QiskitCircuit(2)
+    circuit.cx(0, 1)
+    circuit.h(0)
+
+    result_circuit = compile(
+        circuit,
+    )
+
+    assert set(op.name for op in result_circuit).issubset(
+        {"cx", "rz", "rx", "ry", "h"}
+    )
+
+
 def test_bqskit_compile():
     from ucc.transpilers.ucc_bqskit import BQSKitTransformationPass
 


### PR DESCRIPTION
The current operation is 
1. Identify the target gateset:
    a) `target_device.operation_names` if a target_device is provided, or
     b) the target_gateset if that is provided, or
     c) else {cx, rz, rx, ry, h} if neither is provided.
2. Translate the initial circuit into the provided gateset first, pre-optimization (This may not be necessary, as commenting it out doesn't break any tests, so UnitarySynthesis may be taking care of this).
3. Pass the target gateset to the UnitarySynthesis pass to optimize for that target basis. 

1c) is different than the previous behavior of leaving circuits alone if no target was specified. This way we aren't losing out on the optimization potential of the UnitarySynthesis pass.