### PR TITLE
Draft: Fix use of target device

### DIFF
--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -66,7 +66,7 @@ def compile(
     # Translate into the target device gateset first; no optimization
     basis_translated_circuit = qiskit_transpile(
         qiskit_circuit,
-        basis_gates=ucc_default1.target_gateset,
+        basis_gates=ucc_default1.target_basis,
         optimization_level=0,
     )
 

--- a/ucc/tests/test_compile.py
+++ b/ucc/tests/test_compile.py
@@ -130,39 +130,42 @@ def test_custom_pass():
     post_compiler_circuit = compile(cirq_circuit, custom_passes=[HtoX()])
     assert_same_circuits(post_compiler_circuit, CirqCircuit(X(qubit)))
 
-    def test_compile_target_device_opset():
-        circuit = QiskitCircuit(3)
-        circuit.cx(0, 1)
-        circuit.cx(0, 2)
 
-        # Create a simple target that does not have direct CX between 0 and 2
-        t = Mybackend().target
-        result_circuit = compile(
-            circuit, return_format="original", target_device=t
-        )
-        # Check that the gates in the final circuit are all supported on the target device
-        assert set(op.name for op in result_circuit).issubset(
-            t.operation_names
-        )
+def test_compile_target_device_opset():
+    circuit = QiskitCircuit(3)
+    circuit.cz(0, 1)
+    circuit.cz(0, 2)
+    t = Mybackend().target
 
-    def test_compile_target_device_coupling_map():
-        circuit = QiskitCircuit(3)
-        circuit.cx(0, 1)
-        circuit.cx(0, 2)
+    # Check that the gates in the original circuit are not support by the target
+    # to ensure this isn't a trival check
+    assert set(op.name for op in circuit).issubset(t.operation_names) is False
 
-        # Create a simple target that does not have direct CX between 0 and 2
-        t = Mybackend().target
-        result_circuit = compile(
-            circuit, return_format="original", target_device=t
-        )
-        # Check that the compiled circuit respects the coupling map of the target device
-        analysis_pass = CheckMap(
-            t.build_coupling_map(), property_set_field="check_map"
-        )
+    result_circuit = compile(
+        circuit, return_format="original", target_device=t
+    )
+    # Check that the gates in the final circuit are all supported on the target device
+    assert set(op.name for op in result_circuit).issubset(t.operation_names)
 
-        dag = circuit_to_dag(result_circuit)
-        analysis_pass.run(dag)
-        assert analysis_pass.property_set["check_map"]
+
+def test_compile_target_device_coupling_map():
+    circuit = QiskitCircuit(3)
+    circuit.cx(0, 1)
+    circuit.cx(0, 2)
+
+    # Create a simple target that does not have direct CX between 0 and 2
+    t = Mybackend().target
+    result_circuit = compile(
+        circuit, return_format="original", target_device=t
+    )
+    # Check that the compiled circuit respects the coupling map of the target device
+    analysis_pass = CheckMap(
+        t.build_coupling_map(), property_set_field="check_map"
+    )
+
+    dag = circuit_to_dag(result_circuit)
+    analysis_pass.run(dag)
+    assert analysis_pass.property_set["check_map"]
 
 
 def test_compile_with_no_target_gateset_or_device():

--- a/ucc/transpilers/ucc_defaults.py
+++ b/ucc/transpilers/ucc_defaults.py
@@ -50,8 +50,8 @@ class UCCDefault1:
                 target_device (qiskit.transpiler.Target): (Optional) The target device to compile the circuit for
         """
         self.pass_manager = PassManager()
-        self.target_device = target_device
-        self.target_gateset = target_gateset
+        self._target_device = target_device
+        self._target_gateset = target_gateset
         self._add_local_passes(local_iterations)
         self._add_map_passes(target_device)
 
@@ -62,12 +62,12 @@ class UCCDefault1:
     @property
     def target_basis(self):
         # Use the target device's gateset if available, otherwise use the provided gateset, otherwise
-        if hasattr(self.target_device, "operation_names"):
+        if hasattr(self._target_device, "operation_names"):
             # Use target_device gateset if available
-            target_gateset = self.target_device.operation_names
-        elif self.target_gateset is not None:
+            target_gateset = self._target_device.operation_names
+        elif self._target_gateset is not None:
             # Use provided gateset if available
-            target_gateset = self.target_gateset
+            target_gateset = self._target_gateset
         else:
             # Default if no target device or gateset is provided
             target_gateset = {"cx", "rz", "rx", "ry", "h"}

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <4"
 
 [[package]]
@@ -1562,7 +1562,7 @@ wheels = [
 
 [[package]]
 name = "ucc"
-version = "0.4.8"
+version = "0.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "cirq-core" },


### PR DESCRIPTION
This is a partial fix for an issue introduced in #354 in which some unit tests where indented and not being run. This was hiding two other bugs, one in the implementation in #411 and one I've not yet figured out.

For the unit tests

1. `test_compile_target_device_opset` was running successfully, but not actually testing the behavior because the input circuit gate was already in the basis of the target device. When I switched the input circuit to have a non-supported gate, the test would fail. This was due to the line below, which was not using the newly introduced `target_basis` property. Switching to that now makes the test pass
https://github.com/unitaryfoundation/ucc/blob/4d9a11675319aaf048b0c3137f56adbdc520e03a/ucc/compile.py#L63

2. `test_compile_target_device_coupling_map` is now failing, as the compiled circuit does not satisfy the coupling map. I've not dug in to figure out why yet.