### PR TITLE
chore(license): set AGPL-3.0-only in pyproject.toml to match LICENSE and README

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 repository = "https://github.com/unitaryfoundation/ucc"
 requires-python = ">=3.12,<4"
 packages = [{ include = "ucc" }]
+classifiers = [
+    "License :: OSI Approved :: GNU Affero General Public License v3",
+]
 dependencies = [
     "cirq-core>=1.4.1,<2.0.0",
     "ply>=3.11,<4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     { name = "Nate Stemen" },
     { name = "Brad Chase" },
 ]
-license = "GPL-3.0"
+license = "AGPL-3.0-only"
 readme = "README.md"
 repository = "https://github.com/unitaryfoundation/ucc"
 requires-python = ">=3.12,<4"


### PR DESCRIPTION
This PR fixes a license metadata mismatch. See #499 

- pyproject.toml previously declared GPL-3.0
- Repo LICENSE and README.md state AGPLv3

Change:
- Set `[project].license = "AGPL-3.0-only"` in pyproject.toml to align with LICENSE and README.md.

Follow-ups (optional):
- Verify sdist/wheel license metadata shows AGPL.
- Optionally add a Trove classifier for AGPL: "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)".
