### PR TITLE
fix(aqc): compare and log fidelity using magnitude (np.abs)

### DIFF
--- a/ucc/transpilers/aqc/__init__.py
+++ b/ucc/transpilers/aqc/__init__.py
@@ -64,9 +64,9 @@ def approx_compile(circuit: QuantumCircuit) -> QuantumCircuit:
     # circuit and returns the original one
     # TODO: This should be modified depending on maintainer notes
     fidelity = np.vdot(target_sv, Statevector(aqc_circuit).data)
-    if fidelity < 0.8:
+    if np.abs(fidelity) < 0.8:
         warnings.warn(
-            f"Warning: Fidelity {fidelity:.4f} is too low. Discarding compression."
+            f"Warning: Fidelity {np.abs(fidelity):.4f} is too low. Discarding compression."
         )
         return circuit
 

--- a/ucc/transpilers/aqc/mps_sequential.py
+++ b/ucc/transpilers/aqc/mps_sequential.py
@@ -220,18 +220,18 @@ class Sequential:
 
             fidelity = np.vdot(disentangled_mps.to_dense(), zero_state)
 
-            if fidelity >= self.max_fidelity_threshold:
+            if np.abs(fidelity) >= self.max_fidelity_threshold:
                 # If the disentangled MPS is close enough to the zero state,
                 # we can stop the disentanglement process
                 logger.info(
-                    f"Reached target fidelity {fidelity}. "
+                    f"Reached target fidelity {np.abs(fidelity):.4f}. "
                     f"{layer_index + 1} layers used."
                 )
                 break
 
         if layer_index == max_num_layers - 1:
             logger.info(
-                f"Reached fidelity {fidelity} with "
+                f"Reached fidelity {np.abs(fidelity):.4f} with "
                 f"maximum number of layers {max_num_layers}."
             )
 
@@ -308,7 +308,7 @@ class Sequential:
 
         fidelity = np.vdot(Statevector(circuit).data, statevector)
         logger.info(
-            f"Fidelity: {fidelity:.4f}, "
+            f"Fidelity: {np.abs(fidelity):.4f}, "
             f"Number of qubits: {num_qubits}, "
             f"Number of layers: {max_num_layers}, "
         )

--- a/ucc/transpilers/aqc/qmprs_compiler.py
+++ b/ucc/transpilers/aqc/qmprs_compiler.py
@@ -88,7 +88,7 @@ class QmprsCompiler:
 
         fidelity = np.vdot(circuit.get_statevector(), statevector)
         logger.info(
-            f"Fidelity: {fidelity:.4f}, "
+            f"Fidelity: {np.abs(fidelity):.4f}, "
             f"Number of qubits: {num_qubits}, "
             f"Number of layers: {num_layers}, "
             f"Number of sweeps: {num_sweeps}"


### PR DESCRIPTION
Fidelity from np.vdot is complex; comparisons to float thresholds and logs should use magnitude. This PR contains only the fidelity fix, cherry-picked from #501, without license/TODO changes.\n\nChanges:\n- approx_compile: compare np.abs(fidelity) to threshold; log magnitude.\n- MPS sequential: early-stop and logs use np.abs(fidelity).\n- qmprs compiler: logs use np.abs(fidelity).\n\nRationale:\n- Fidelity is |⟨ψ|ϕ⟩| in [0,1] and invariant to global phase. Comparing the complex value directly can misclassify high-fidelity states with phase.\n\nNo behavior changes for real-overlap cases; fixes misclassification/formatting for complex overlaps.