### PR TITLE
fix(compile): use resolved target_basis for pre-translation basis_gates

### DIFF
--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -20,7 +20,7 @@ if current_major != REQUIRED_MAJOR or not (
 ):
     warnings.warn(
         f"Warning: This package is designed for Python {REQUIRED_MAJOR}.{MINOR_VERSION_MIN}-{REQUIRED_MAJOR}.{MINOR_VERSION_MAX}. "
-        f"You are using Python) {current_major}.{current_minor}."
+        f"You are using Python {current_major}.{current_minor}."
     )
 supported_circuit_formats = ConversionGraph().nodes()
 
@@ -42,7 +42,7 @@ def compile(
             e.g., "TKET", "OpenQASM2". Check ``ucc.supported_circuit_formats``.
             Defaults to the format of the input circuit.
         target_gateset (set[str]): (optional) The gateset to compile the circuit to.
-            e.g. {"cx", "rx",...}. Defaults to the gate set of the target device if available. If no `target_gateset` or ` target_device` is provided, defaults to `{"cx", "rz", "rx", "ry", "h"}`.
+            e.g. {"cx", "rx",...}. Defaults to the gate set of the target device if available. If no `target_gateset` or ` target_device` is provided, defaults to {"cx", "rz", "rx", "ry", "h"}.
         target_device (qiskit.transpiler.Target): (optional)
             The target device  to compile the circuit for. Can be specified as a Qiskit backend. If None, all-to-all connectivity is assumed. If a `target_device` is specified, `target_device.operation_names` supercedes the `target_gateset`.
         custom_passes (list[qiskit.transpiler.TransformationPass]): (optional)
@@ -66,7 +66,7 @@ def compile(
     # Translate into the target device gateset first; no optimization
     basis_translated_circuit = qiskit_transpile(
         qiskit_circuit,
-        basis_gates=ucc_default1.target_gateset,
+        basis_gates=ucc_default1.target_basis,
         optimization_level=0,
     )
 


### PR DESCRIPTION
Pre-translation currently uses the raw target_gateset (possibly None), which can ignore the device opset or default gates. This change switches to the resolved target_basis (device → user → default) to align with the pass manager and the intent described in comments.

Fixes #503.