### PR TITLE
Use resolved target_basis for pre-translation basis_gates

### DIFF
--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -66,7 +66,7 @@ def compile(
     # Translate into the target device gateset first; no optimization
     basis_translated_circuit = qiskit_transpile(
         qiskit_circuit,
-        basis_gates=ucc_default1.target_basis,
+        basis_gates=ucc_default1.target_gateset,
         optimization_level=0,
     )
 

--- a/ucc/tests/test_compile.py
+++ b/ucc/tests/test_compile.py
@@ -130,20 +130,23 @@ def test_custom_pass():
     post_compiler_circuit = compile(cirq_circuit, custom_passes=[HtoX()])
     assert_same_circuits(post_compiler_circuit, CirqCircuit(X(qubit)))
 
-    def test_compile_target_device_opset():
-        circuit = QiskitCircuit(3)
-        circuit.cx(0, 1)
-        circuit.cx(0, 2)
 
-        # Create a simple target that does not have direct CX between 0 and 2
-        t = Mybackend().target
-        result_circuit = compile(
-            circuit, return_format="original", target_device=t
-        )
-        # Check that the gates in the final circuit are all supported on the target device
-        assert set(op.name for op in result_circuit).issubset(
-            t.operation_names
-        )
+def test_compile_target_device_opset():
+    circuit = QiskitCircuit(3)
+    circuit.cz(0, 1)
+    circuit.cz(0, 2)
+
+    # Create a simple target that does not have direct CX between 0 and 2
+    t = Mybackend().target
+    # Check that the gates in the original circuit are not support by the target
+    # to ensure this isn't a trival check
+    assert set(op.name for op in circuit).issubset(t.operation_names) is False
+
+    result_circuit = compile(
+        circuit, return_format="original", target_device=t
+    )
+    # Check that the gates in the final circuit are all supported on the target device
+    assert set(op.name for op in result_circuit).issubset(t.operation_names)
 
     def test_compile_target_device_coupling_map():
         circuit = QiskitCircuit(3)
@@ -167,6 +170,21 @@ def test_custom_pass():
 
 def test_compile_with_no_target_gateset_or_device():
     """Test that the final circuit is in the default gateset if no `target_gateset` or `target_device` is provided."""
+
+    # Circuit not in the default target_gateset {"cx", "rz", "rx", "ry", "h"}
+    circuit = QiskitCircuit(2)
+    circuit.cz(0, 1)
+    circuit.h(0)
+
+    result_circuit = compile(
+        circuit,
+    )
+
+    assert set(op.name for op in result_circuit).issubset(
+        {"cx", "rz", "rx", "ry", "h"}
+    )
+
+    # Circuit already in the default target_gateset {"cx", "rz", "rx", "ry", "h"}
     circuit = QiskitCircuit(2)
     circuit.cx(0, 1)
     circuit.h(0)
@@ -559,7 +577,7 @@ def test_compile_with_target_gateset():
 def test_compilation_retains_gateset(circuit_function, num_qubits, seed):
     circuit = circuit_function(num_qubits, seed)
     transpiler = UCCDefault1()
-    target_basis = transpiler.target_basis
+    target_basis = transpiler.target_gateset
     transpiled_circuit = transpiler.run(circuit)
     dag = circuit_to_dag(transpiled_circuit)
     analysis_pass = GatesInBasis(basis_gates=target_basis)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <4"
 
 [[package]]
@@ -1562,7 +1562,7 @@ wheels = [
 
 [[package]]
 name = "ucc"
-version = "0.4.8"
+version = "0.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "cirq-core" },


### PR DESCRIPTION
Extends the fix in #504 to re-enable corresponding unit tests that were accidentally being skipped, and initializes `target_gateset` in the constructor versus as a property to avoid having both `self.target_gateset` and `self.target_basis` variables.

Resolves #503