### PR TITLE
Ignore test code in test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+omit =
+    */tests/*
+
+[report]
+exclude_lines =
+    # pragma: no cover


### PR DESCRIPTION
Related to #479 and as noticed by @ACE07-Sev, this change should ignore unit test code itself when calculating code coverage.